### PR TITLE
Fixed non-ascii chars and latex deprecations

### DIFF
--- a/Modules/SOR3012
+++ b/Modules/SOR3012
@@ -15,7 +15,7 @@ LEARNINGOUTCOMES:
 
 - You should be able to calculate expectations and variances directly, using the moment generating function and by using the conditional expectation theorem.  You should also be able to explain what predictions can be made given the expectation and/or the variance.
 
-- You should be able to recognise which type of random variable is appropriate for modelling a given phenomenon, identify the assumptions that they have made in constructing this model and critically assess their validity. 
+- You should be able to recognise which type of random variable is appropriate for modelling a given phenomenon, identify the assumptions that they have made in constructing this model and critically assess their validity.  
 
 - You should be able to explain what it means when we state that a time dependent process has independent and stationary increments and how this differs from a Markov process.  By using your understanding of this distinction you should be able to construct probabilistic models for time dependent phenomena, explain the assumptions that have been made in the constructing these models and critically assess their validity.
 

--- a/Resources/2-level-exercise.tex
+++ b/Resources/2-level-exercise.tex
@@ -22,7 +22,7 @@ title=#1
 %\begin{tcolorbox}[colback=blue!05,width=\textwidth]
 % #3
 %\end{tcolorbox}
-\Huge {\bf  #2}
+\Huge {\bfseries  #2}
 \tcblower
 #3
 \end{tcolorbox}

--- a/Resources/bayes-theorem-problems.xml
+++ b/Resources/bayes-theorem-problems.xml
@@ -58,8 +58,8 @@ $$
 Marie is getting married tomorrow, at an outdoor ceremony in the desert. In recent
 years, it has rained only 5 days each year. Unfortunately, the weatherman has predicted rain
 for tomorrow. When it actually rains, the weatherman correctly forecasts rain 90 % of the time.
-When it doesn’t rain, he incorrectly forecasts rain 10 % of the time. What is the probability that
-it will rain on the day of Marie’s wedding? (Assume that there are no leap years)
+When it doesn't rain, he incorrectly forecasts rain 10 % of the time. What is the probability that
+it will rain on the day of Marie's wedding? (Assume that there are no leap years)
 </QUESTION>
       <SOLUTION>
 $$

--- a/Resources/betrand-paradox-project.tex
+++ b/Resources/betrand-paradox-project.tex
@@ -50,7 +50,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 

--- a/Resources/binomial-random-variable-project.tex
+++ b/Resources/binomial-random-variable-project.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on binomial random variables.  You should prepare your report as an ipython notebook and within it you should present:
+For this project you must produce a {\bfseries three page} set of notes on binomial random variables.  You should prepare your report as an ipython notebook and within it you should present:
 
 \begin{itemize}
  \item An explanation on the type of experiments that this random variable can be used to model. 

--- a/Resources/central-limit-theorem-problems.xml
+++ b/Resources/central-limit-theorem-problems.xml
@@ -55,7 +55,7 @@ f_{X}(x) =
 \right.
 $$
 Calculate $\mathbb{E}(X)=\mu$ and $\sqrt{\textrm{var}(X)}=\sigma$ and hence use the central limit 
-theorem to estimate the probability  that the price will increase by £1.20 , or more,  after 3  hours. 
+theorem to estimate the probability  that the price will increase by \pounds~1.20 , or more,  after 3  hours. 
 </QUESTION>
       <SOLUTION>
 WE are given information on a random variable in the question.  We can use this information to 

--- a/Resources/central-limit-theorem-proof.tex
+++ b/Resources/central-limit-theorem-proof.tex
@@ -53,7 +53,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 

--- a/Resources/closed-1D-ising-model.tex
+++ b/Resources/closed-1D-ising-model.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{AMA4004:
 Statistical Mechanics} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Statistical Mechanics} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on the 1D-closed Ising model.  You should prepare your report as an ipython notebook and within 
+For this project you must produce a {\bfseries three page} set of notes on the 1D-closed Ising model.  You should prepare your report as an ipython notebook and within 
 it you should present:
 
 \begin{itemize}

--- a/Resources/conditional-probability-problems.xml
+++ b/Resources/conditional-probability-problems.xml
@@ -11,7 +11,7 @@ $$
 </DESCRIPTION>
   <EXAMPLE>
     <QUESTION>
-There are $n$ boxes, one with a prize of £100, the others are empty. 
+There are $n$ boxes, one with a prize of \pounds~100, the others are empty. 
 A group of $n$ people are asked to form a  queue  and choose a box (at random) 
 each in turn. Bob complains that this gives an unfair advantage to those first
 in the queue.  

--- a/Resources/ehrenfest-urns-program.tex
+++ b/Resources/ehrenfest-urns-program.tex
@@ -50,7 +50,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 

--- a/Resources/ensembles-exercise.tex
+++ b/Resources/ensembles-exercise.tex
@@ -22,7 +22,7 @@ title=#1
 %\begin{tcolorbox}[colback=blue!05,width=\textwidth]
 % #3
 %\end{tcolorbox}
-\Huge {\bf  #2}
+\Huge {\bfseries  #2}
 \tcblower
 #3
 \end{tcolorbox}

--- a/Resources/estimating-pi-project.tex
+++ b/Resources/estimating-pi-project.tex
@@ -50,7 +50,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 

--- a/Resources/exponential-random-variable-problems.xml
+++ b/Resources/exponential-random-variable-problems.xml
@@ -207,7 +207,7 @@ Once you realise this the solution is the same as that for the above problem wit
       <QUESTION>
 A company offers to fix the mobile phones bought by its customers.
 These phones break in one of two ways: either the battery fails, which costs
-£20 to fix, or the screen breaks, which costs £30 to
+\pounds~20 to fix, or the screen breaks, which costs \pounds~30 to
 fix.  If the time taken for the battery to fail is given by an exponentially
 distributed random variable with parameter $\lambda$ and the time taken for the
 screen to break is given by an exponentially distributed random variable with
@@ -222,11 +222,11 @@ The key to solving this problem is recognizing three things:
 <ul>
 <li> The amount of time taken for the screen to break is a random variable, $X$, with cumulative probability distribution function: $P(X \le x) = 1 - e^{-\lambda x}$ </li>
 <li> The amount of time taken for the battery to fail is a random variable, $Y$, with cumulative probability distribution function: $P(Y \le y) = 1 - e^{-\mu y}$ </li>
-<li> If $P(Y \lt X)$ then the company has to pay out £20 and if $P(X \lt Y)$ the company has to pay out £30. </li>
+<li> If $P(Y \lt X)$ then the company has to pay out \pounds~20 and if $P(X \lt Y)$ the company has to pay out \pounds~30. </li>
 </ul>
 You can determine the two probabilities in the third item above using the same method that was used to solve the problem with Alice and Bob above.
 These two probabilities will add up to one as such you can think of this pair of probabilities as the probability mass function for a discrete 
-random variable with two possible outcomes - a cost of £30 to the company or a cost of £20 to the company.  Calculating the expectation of this
+random variable with two possible outcomes - a cost of \pounds~30 to the company or a cost of \pounds~20 to the company.  Calculating the expectation of this
 random variable is straightforward.
 </SOLUTION>
     </EXAMPLE>

--- a/Resources/exponential-random-variable-project.tex
+++ b/Resources/exponential-random-variable-project.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on exponential random variables.  You should prepare your report as an ipython notebook and within it you should present:
+For this project you must produce a {\bfseries three page} set of notes on exponential random variables.  You should prepare your report as an ipython notebook and within it you should present:
 
 \begin{itemize}
  \item An explanation on the type of experiments that this random variable can be used to model. 

--- a/Resources/gamblers-ruin-expectation.tex
+++ b/Resources/gamblers-ruin-expectation.tex
@@ -47,7 +47,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 

--- a/Resources/gamblers-ruin-probability.tex
+++ b/Resources/gamblers-ruin-probability.tex
@@ -47,7 +47,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -69,7 +69,7 @@ Regardless this event occurs with a probablilty of $p$.  If the event transpires
 holding.  If it does not transpire you loose your stake and are thus left with $a - x$ pounds.  
 
 The ideas in this first paragraph have been covered in the videos on the gamblers video and in the programming exercise.  We have shown how we can describe the above process using a Markov chain, 
-what the transition graph is for this chain and what the associated one-step transition probability matrix is for this discrete Markov chain.  {\bf Before attempting this exercise make sure you are 
+what the transition graph is for this chain and what the associated one-step transition probability matrix is for this discrete Markov chain.  {\bfseries Before attempting this exercise make sure you are 
 familiar with these ideas and that you can thus do the following items:}
 
 \begin{enumerate}
@@ -80,7 +80,7 @@ familiar with these ideas and that you can thus do the following items:}
 you start with $k$ pounds and where $p$ and $q$ are the probabiltiy of winning when you place each stake.
 \end{enumerate}
 
-{\bf If you cannot do all of the above things watch the video on gamblers ruin again.  If you are unable to do the above you will not understand the remainder of this exercise.}
+{\bfseries If you cannot do all of the above things watch the video on gamblers ruin again.  If you are unable to do the above you will not understand the remainder of this exercise.}
 
 The purpose of this exercise is to find an exact expression for the conditional probability of ruin given that you start with exactly $k$ pounds, $\pi_k$.
 
@@ -103,7 +103,7 @@ solutions we find - so for example if we find two solutions, $\theta_1$ and $\th
 \[
  \phi_k = A \theta_1^k + B \theta_2^k
 \]
-{\bf Insert the trial solution $\pi_k = \theta^k$ into the homogenous difference equation above remebering that $\phi_{k+1}=\theta^{k+1}$.  Factorise the resulting equation and hence show that:
+{\bfseries Insert the trial solution $\pi_k = \theta^k$ into the homogenous difference equation above remebering that $\phi_{k+1}=\theta^{k+1}$.  Factorise the resulting equation and hence show that:
 
 \begin{equation}
  \pi_k = A + B \left( \frac{q}{p}\right)^k
@@ -112,11 +112,11 @@ solutions we find - so for example if we find two solutions, $\theta_1$ and $\th
 
 where $A$ and $B$ are as yet unknown parameters.}
 
-\item Think about what the quantity $\pi_k$ represents.  This is the probability of ruin given that you start with exactly $k$ pounds to your name.  Given the meaning of this quantity, $\pi_k$, {\bf 
+\item Think about what the quantity $\pi_k$ represents.  This is the probability of ruin given that you start with exactly $k$ pounds to your name.  Given the meaning of this quantity, $\pi_k$, {\bfseries 
 what are the values of $\pi_0$ and $\pi_n$.}  Notice that here $n$ is the target amount of money the gambler wants to win.  
 
 \item If you insert the values of $\pi_0$ and $\pi_n$ into the left hand side of equation \ref{eqn:soln} and the corresponding values of $k$ into the right hand side you get two simulaltaneous 
-equation with two unknowns $A$ and $B$.  {\bf Solve this set of simultaneous equations and find values for $A$ and $B$.}  Hence, show that:
+equation with two unknowns $A$ and $B$.  {\bfseries Solve this set of simultaneous equations and find values for $A$ and $B$.}  Hence, show that:
 \[
  \pi_k = \frac{ \left( \frac{q}{p} \right)^k - \left( \frac{q}{p} \right)^n }{ 1 - \left( \frac{q}{p} \right)^n }
 \]

--- a/Resources/gamblers-ruin-program.tex
+++ b/Resources/gamblers-ruin-program.tex
@@ -50,7 +50,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 

--- a/Resources/geometric-random-variable-project.tex
+++ b/Resources/geometric-random-variable-project.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on geometric random variables.  You should prepare your report as an ipython notebook and within it you should present:
+For this project you must produce a {\bfseries three page} set of notes on geometric random variables.  You should prepare your report as an ipython notebook and within it you should present:
 
 \begin{itemize}
  \item An explanation on the type of experiments that this random variable can be used to model. 

--- a/Resources/info-theory-video1.xml
+++ b/Resources/info-theory-video1.xml
@@ -3,7 +3,7 @@
   <VIDEO>https://www.youtube.com/embed/xdo1t6_so20</VIDEO>
   <UL>
     <LI> Explain the meaning of the term functional</LI>
-    <LI> State Khitchine’s four axioms for the information</LI>
+    <LI> State Khitchine's four axioms for the information</LI>
     <LI> Explain what we mean when we state that a function or functional is monotonically decreasing.</LI>
     <LI> Now explain why the information in a uniform distribution decreases monotonically with the size of the sample space.</LI>
     <LI> If the uniform probability distribution $p$ has a sample space with $m$ outcomes and the probability distribution $q$ has a sample space with $n$ outcomes. How many outcomes are there in the sample space for the joint probability distribution $p \otimes q$. N.B. $p$ and $q$ are independent.</LI>

--- a/Resources/lagrange-multipliers-video.xml
+++ b/Resources/lagrange-multipliers-video.xml
@@ -6,8 +6,8 @@
     <LI> At the (unconstrainted) optimum the grad of the function is equal to</LI>
     <LI> Is the grad of a function, $\nabla f(x,y)$, a scalar or a vector quantity</LI>
     <LI> Complete the following sentence: At a constrained optimum the grad of the function and the grad of the constraint...</LI>
-    <LI> Explain (in your own words) the purpose of Lagrange’s method of undetermined multipliers</LI>
-    <LI> State the two steps in Lagrange’s method of undetermined multipliers</LI>
+    <LI> Explain (in your own words) the purpose of Lagrange's method of undetermined multipliers</LI>
+    <LI> State the two steps in Lagrange's method of undetermined multipliers</LI>
     <LI> Write an expression for the extended function that must be optimised in order to optimise the function $f(x,y)$ subject to the constraint $g(x,y)=c$</LI>
   </UL>
 </PAGE>

--- a/Resources/limit-squeeze-problems.xml
+++ b/Resources/limit-squeeze-problems.xml
@@ -15,7 +15,7 @@ $$
 $$
 </QUESTION>
       <SOLUTION>
-If we put the equation in the question into words we are being asked to ``find the limit of $\sin(x)$ over $x$ as $x$ tends to infinity.” 
+If we put the equation in the question into words we are being asked to ``find the limit of $\sin(x)$ over $x$ as $x$ tends to infinity.'' 
 In more prosaic terms substitute $\infty$ into the equation after the limit sign and see what happens. Obviously, this is not a problem 
 we can solve with a calculator as (a) we cannot put infinity into a calculator and (b) even if we could the value of 
 $\frac{\infty}{\infty}$ is undefined. We thus have to use some other scheme.  For this particular problem we solve the limit as follows:

--- a/Resources/markov-stationary-distribution-problems.xml
+++ b/Resources/markov-stationary-distribution-problems.xml
@@ -190,7 +190,7 @@ $$
       <QUESTION>
 A double glazing firm employs staff to cold call clients and try to sell
 them new windows for their home. There are three levels of staff pay: Level 1
-(£50), Level 2 (£75) or Level 3 (£100).  The amount a
+(\pounds~50), Level 2 (\pounds~75) or Level 3 (\pounds~100).  The amount a
 person is paid in a given evening is determined by their performance
 that evening and their performance on the previous evening.  A staff member who
 was paid at level 1 on the previous day is moved to level 2 if they are

--- a/Resources/mean-field-2-ising-model.tex
+++ b/Resources/mean-field-2-ising-model.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{AMA4004:
 Statistical Mechanics} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Statistical Mechanics} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on modelling the Ising model within a mean field theory where the interactions between neighboring spins is modelled exactly and where each pair of spins then interacts with the mean field.  You should prepare your report as 
+For this project you must produce a {\bfseries three page} set of notes on modelling the Ising model within a mean field theory where the interactions between neighboring spins is modelled exactly and where each pair of spins then interacts with the mean field.  You should prepare your report as 
 an ipython notebook and within it you should present:
 
 \begin{itemize}

--- a/Resources/mean-field-ising-model.tex
+++ b/Resources/mean-field-ising-model.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{AMA4004:
 Statistical Mechanics} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Statistical Mechanics} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on modelling the Ising model within a mean field theory where each spin interacts with the mean field.  You should prepare your report as an ipython notebook and within 
+For this project you must produce a {\bfseries three page} set of notes on modelling the Ising model within a mean field theory where each spin interacts with the mean field.  You should prepare your report as an ipython notebook and within 
 it you should present:
 
 \begin{itemize}

--- a/Resources/medical-markov-chains-project.tex
+++ b/Resources/medical-markov-chains-project.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on how the progression of diseases can be modelled using continuous time Markov chains.  You should prepare your report as an 
+For this project you must produce a {\bfseries three page} set of notes on how the progression of diseases can be modelled using continuous time Markov chains.  You should prepare your report as an 
 ipython notebook and within it you should present:
 
 \begin{itemize}
@@ -83,7 +83,7 @@ ipython notebook and within it you should present:
 \end{itemize}
 
 You should also explain any results you have used on series expansions or special integrals within your notes and provide the reader with links explaining where they can find material that explains 
-these ideas.  These links might be pointers to particular websites, pointers to notes from modules that you have studied at Queen's or pointers to websites.  You {\bf should not} get bogged down in 
+these ideas.  These links might be pointers to particular websites, pointers to notes from modules that you have studied at Queen's or pointers to websites.  You {\bfseries should not} get bogged down in 
 explaining what a Markov chain is, how the Kolmogorov equations are derived and so on. You can assume that the readers of your report will have studied what you have in SOR3012 and that they will thus
 be familiar with these details.
 

--- a/Resources/molecular-partition-function.tex
+++ b/Resources/molecular-partition-function.tex
@@ -22,7 +22,7 @@ title=#1
 %\begin{tcolorbox}[colback=blue!05,width=\textwidth]
 % #3
 %\end{tcolorbox}
-\Huge {\bf  #2}
+\Huge {\bfseries  #2}
 \tcblower
 #3
 \end{tcolorbox}
@@ -82,7 +82,7 @@ Use this result to determine expressions for the average energy of the particle 
 
 \item Discuss the behaviour of the heat capacity of the harmonic oscillator and the particle in a box in the low temperature limit.  In which of these two systems does the behaviour of the heat capacity deviate from the predictions of equipartition?  Why does this deviation occur for this particular system and why does it not occur for the other system you studied?  
 
-\item Lets now consider a system of $N$ uncoupled harmonic oscillators with characteristic frequencies $\{ \omega_1, \omega_2, \dots \omega_N\}$.  Explain what the heat capacity for this system will equal in the high temperature limit {\bf without} doing any derivations.
+\item Lets now consider a system of $N$ uncoupled harmonic oscillators with characteristic frequencies $\{ \omega_1, \omega_2, \dots \omega_N\}$.  Explain what the heat capacity for this system will equal in the high temperature limit {\bfseries without} doing any derivations.
 
 \item Explain why the canonical partition function for this system of $N$ uncoupled harmonic oscillators is given by:
 $$

--- a/Resources/normal-random-variable-project.tex
+++ b/Resources/normal-random-variable-project.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on normal random variables.  You should prepare your report as an ipython notebook and within it you should present:
+For this project you must produce a {\bfseries three page} set of notes on normal random variables.  You should prepare your report as an ipython notebook and within it you should present:
 
 \begin{itemize}
  \item An explanation on the type of experiments that this random variable can be used to model. 

--- a/Resources/open-1D-ising-model.tex
+++ b/Resources/open-1D-ising-model.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{AMA4004:
 Statistical Mechanics} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Statistical Mechanics} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on the 1D-open Ising model.  You should prepare your report as an ipython notebook and within 
+For this project you must produce a {\bfseries three page} set of notes on the 1D-open Ising model.  You should prepare your report as an ipython notebook and within 
 it you should present:
 
 \begin{itemize}

--- a/Resources/poisson-process-project.tex
+++ b/Resources/poisson-process-project.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on the Poisson Process.  You should prepare your report as an ipython notebook and within it you should present:
+For this project you must produce a {\bfseries three page} set of notes on the Poisson Process.  You should prepare your report as an ipython notebook and within it you should present:
 
 \begin{itemize}
  \item You should discuss phenomena that can be modelled using a Poisson process and you should discuss the assumptions that are made when this model is used to model these phenomena
@@ -81,7 +81,7 @@ For this project you must produce a {\bf three page} set of notes on the Poisson
 \end{itemize}
 
 You should also explain any results you have used on series expansions or special integrals within your notes and provide the reader with links explaining where they can find material that explains 
-these ideas.  These links might be pointers to particular websites, pointers to notes from modules that you have studied at Queen's or pointers to websites.  You {\bf should not} get bogged down in 
+these ideas.  These links might be pointers to particular websites, pointers to notes from modules that you have studied at Queen's or pointers to websites.  You {\bfseries should not} get bogged down in 
 explaining what a Markov chain is, how the Kolmogorov equations are derived and so on. You can assume that the readers of your report will have studied what you have in SOR3012 and that they will thus
 be familiar with these details.
 

--- a/Resources/poisson-random-variable-project.tex
+++ b/Resources/poisson-random-variable-project.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on poisson random variables.  You should prepare your report as an ipython notebook and within it you should present:
+For this project you must produce a {\bfseries three page} set of notes on poisson random variables.  You should prepare your report as an ipython notebook and within it you should present:
 
 \begin{itemize}
  \item An explanation on the type of experiments that this random variable can be used to model. 

--- a/Resources/potts-model.tex
+++ b/Resources/potts-model.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{AMA4004:
 Statistical Mechanics} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Statistical Mechanics} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on the Potts model.  You should prepare your report as an ipython notebook and within 
+For this project you must produce a {\bfseries three page} set of notes on the Potts model.  You should prepare your report as an ipython notebook and within 
 it you should present:
 
 \begin{itemize}

--- a/Resources/queues-project.tex
+++ b/Resources/queues-project.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on the M/M/1 queue.  You should prepare your report as an ipython notebook and within it you should present:
+For this project you must produce a {\bfseries three page} set of notes on the M/M/1 queue.  You should prepare your report as an ipython notebook and within it you should present:
 
 \begin{itemize}
 \item You should discuss how a model can be constructed by using the theory of continuous time Markov chains.  In this discussion you should talk about the distinction between infinite 
@@ -85,7 +85,7 @@ and you may also want to include an analytical solution to this model.
 \end{itemize}
 
 You should also explain any results you have used on series expansions or special integrals within your notes and provide the reader with links explaining where they can find material that explains 
-these ideas.  These links might be pointers to particular websites, pointers to notes from modules that you have studied at Queen's or pointers to websites.  You {\bf should not} get bogged down in 
+these ideas.  These links might be pointers to particular websites, pointers to notes from modules that you have studied at Queen's or pointers to websites.  You {\bfseries should not} get bogged down in 
 explaining what a Markov chain is, how the Kolmogorov equations are derived and so on. You can assume that the readers of your report will have studied what you have in SOR3012 and that they will thus
 be familiar with these details.
 

--- a/Resources/uniform-random-variable-project.tex
+++ b/Resources/uniform-random-variable-project.tex
@@ -49,7 +49,7 @@
 \newcommand{\horrule}[1]{\rule{\linewidth}{#1}}
 \newcommand{\vek}[1]{\mbox{\boldmath $  #1$}}
 \newcommand{\ex}[1]{\ensuremath {\mathbb{E}} \left[ #1 \right]}
-\newcommand{\var}[1]{\ensuremath{{\rm var}\left[ #1 \right]}}
+\newcommand{\var}[1]{\ensuremath{{\mathrm var}\left[ #1 \right]}}
 
 \title{\usefont{OT1}{bch}{b}{n} \normalfont \normalsize \textsc{SOR3012:
 Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm] 
@@ -66,7 +66,7 @@ Stochastic Processes} \\ [25pt] \horrule{0.5pt} \\[0.4cm]
 \begin{document}
 \maketitle
 
-For this project you must produce a {\bf three page} set of notes on both discrete uniform and continuous uniform random variables.  You should prepare your report as an ipython notebook and within 
+For this project you must produce a {\bfseries three page} set of notes on both discrete uniform and continuous uniform random variables.  You should prepare your report as an ipython notebook and within 
 it you should present:
 
 \begin{itemize}

--- a/SOR3012-tutorials/Week04/tutorial.tex
+++ b/SOR3012-tutorials/Week04/tutorial.tex
@@ -54,7 +54,7 @@ f_{X}(x) =
 \right.
 $$
 Calculate $\mathbb{E}(X)=\mu$ and $\sqrt{\textrm{var}(X)}=\sigma$ and hence use the central limit
-theorem to estimate the probability  that the price will increase by £1.20 , or more,  after 3  hours.
+theorem to estimate the probability  that the price will increase by \pounds~1.20 , or more,  after 3  hours.
 
 \section{Question 3}
 

--- a/SOR3012-tutorials/Week08/tutorial.tex
+++ b/SOR3012-tutorials/Week08/tutorial.tex
@@ -76,7 +76,7 @@ balance condition.
 
 A double glazing firm employs staff to cold call clients and try to sell
 them new windows for their home. There are three levels of staff pay: Level 1
-(£50), Level 2 (£75) or Level 3 (£100).  The amount a
+(\pounds~50), Level 2 (\pounds~75) or Level 3 (\pounds~100).  The amount a
 person is paid in a given evening is determined by their performance
 that evening and their performance on the previous evening.  A staff member who
 was paid at level 1 on the previous day is moved to level 2 if they are

--- a/Scripts/basicgraph.py
+++ b/Scripts/basicgraph.py
@@ -88,10 +88,10 @@ class basicgraph:
                  graphstr += "edge[style=invis];\n"
                  graphstr += backnodes[len(backnodes)-2] + " -> " + self.nodes[j] + '\n'
              backnodes.append(self.nodes[j])
-      for i in range(0,math.floor(len(forwardnodes)/2)+1) :
+      for i in range(0,int(math.floor(len(forwardnodes)/2)+1)) :
           if len(forwardnodes)>2*i+2 :  
              graphstr += "{ rank=same; " + forwardnodes[2*i] + ";" + forwardnodes[2*i+1] + "; } \n" 
-      for i in range(0,math.floor(len(backnodes)/2)+1) :
+      for i in range(0,int(math.floor(len(backnodes)/2)+1)) :
           if len(backnodes)>2*i+2 : 
              graphstr += "{ rank=same; " + backnodes[2*i] + ";" + backnodes[2*i+1] + "; } \n"
       graphstr += "}" 

--- a/Scripts/classifyResourceGui.py
+++ b/Scripts/classifyResourceGui.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from topic import topiclist
 import os 
 from PyQt4.QtGui import *

--- a/Scripts/createHTMLFromXML.py
+++ b/Scripts/createHTMLFromXML.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import sys
 import shutil

--- a/Scripts/createModulePages.py
+++ b/Scripts/createModulePages.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import shutil
 import topic
 import basicgraph

--- a/Scripts/createTopicPage.py
+++ b/Scripts/createTopicPage.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import shutil
 import topic
 import basicgraph

--- a/Scripts/fullgui.py
+++ b/Scripts/fullgui.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import shutil
 import webbrowser
 import basicgraph


### PR DESCRIPTION
make errors resulting from non-ascii characters in python files in ./Scripts
were corrected by adding encoding information to the heads of the files.

make errors arising from non-ascii characters in latex and xml files were
corrected by using correct ascii quote marks and the latex command \pounds.

make errors arising from deprecated latex commands `\rm` and `\bf` were
corrected by replacement with `\textrm`, `\mathrm` or `\bfseries` as appropriate